### PR TITLE
frontendのnode_modulesをcommit対象から除外の依頼

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+frontend/node_modules/


### PR DESCRIPTION
リモートリポジトリからの変更をローカルに反映させるときに
frontendのnode_modulesもコミットされてしまいます。
.gitignoreに以下を追加記載してもいいでしょうか

frontend/node_modules/