### PR TITLE
DayOfWeekHeadの名前付きエクスポートを削除

### DIFF
--- a/frontend/src/components/DayOfWeekHead.tsx
+++ b/frontend/src/components/DayOfWeekHead.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const DayOfWeekHead = () => {
+const DayOfWeekHead = () => {
   const weeks = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
   return (


### PR DESCRIPTION
DayOfWeekHeadが名前付きエクスポートとデフォルトエクスポートで混在していたため、デフォルトエクスポートのみにした